### PR TITLE
Fix docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Description
 
-Get your own file hosting service in minutes. This is the hosted version of Firefiles, Make sure you check the [docs](https://firefiles.vercel.app/docs/intro) before getting started.
+Get your own file hosting service in minutes. This is the hosted version of Firefiles, Make sure you check the [docs](https://firefiles.vercel.app/docs) before getting started.
 
 
 # Features


### PR DESCRIPTION
I seem to be getting an error on `/docs/intro`, but it seems to work with just `/docs`.
<img width="882" alt="Screen Shot 2022-01-24 at 11 32 16 AM" src="https://user-images.githubusercontent.com/72365100/150851605-c2012c6e-343f-4875-be57-71498168613a.png">
