### PR TITLE
Fixes bug with file sort into empty folder

### DIFF
--- a/apps/web/components/Dashboard.tsx
+++ b/apps/web/components/Dashboard.tsx
@@ -55,7 +55,10 @@ const Dashboard = () => {
 	}, [fileSort]);
 
 	useEffect(() => {
-		if (!files) return;
+		if (!files) {
+			setSortedFiles([]);
+			return;
+		}
 
 		const sortedFiles = sortBy(files, fileSort.property);
 		if (!fileSort.isAscending) sortedFiles.reverse();


### PR DESCRIPTION
Fixes a bug that occurs when opening an empty folder. Previous state showed the contents of the previously opened folder; with fix the sortedFiles state will be changed to an empty DriveFile array when there are no files to sort rather than remaining in state from the previously opened folder.