### PR TITLE
Fix: useFirebase addFile null check

### DIFF
--- a/apps/web/hooks/useFirebase.tsx
+++ b/apps/web/hooks/useFirebase.tsx
@@ -188,7 +188,7 @@ export const FirebaseProvider: React.FC<PropsWithChildren<Props>> = ({
 						bucketName: uploadTask.snapshot.metadata.bucket,
 						url: await getDownloadURL(fileRef),
 					};
-					setFiles((files) => [...files, newFile]);
+					setFiles((files) => [...(files || []), newFile]);
 					toast.success("File uploaded successfully.");
 				},
 			);


### PR DESCRIPTION
Resolves issue #53 
Before adding a `newFile` to an empty folder, the implementation for the Firebase API will now check if there is a `files` value to iterate on, if not an empty array will be used.