### PR TITLE
Fix: Redirect Race Condition & Drive Post Schema

### DIFF
--- a/apps/web/components/ui/InviteNotification.tsx
+++ b/apps/web/components/ui/InviteNotification.tsx
@@ -45,7 +45,7 @@ export default function InviteNotification() {
           >
             <Bell size={24} strokeWidth={1.5} />
           </Button>
-          {data.length > 0 ? (
+          {data?.length > 0 ? (
             <Badge
               onClick={() => {
                 onOpen();

--- a/apps/web/pages/api/drive.ts
+++ b/apps/web/pages/api/drive.ts
@@ -36,12 +36,12 @@ const getDriveSchema = z.object({
 /**
  * Schema for performing a POST operation for a Drive record.
  *
- * @param {string} data - A required decrypted drive data body parameter
+ * @param {JSON} data - A required decrypted drive data body parameter
  * @param {string} name - A required drive name body parameter
  * @param {string} type - A required drive type body parameter
  */
 const postDriveSchema = z.object({
-  data: z.string().nonempty(),
+  data: z.record(z.unknown()), // TODO: Parse func to check for specific drive type properties
   name: z.string().nonempty(),
   type: z.string().nonempty(),
 });


### PR DESCRIPTION
Addresses fix related to #70 

Changes:
- Race condition on InviteNotification and useUser /login redirect resolved by changing a dependent operation to be conditional
- Drive's POST schema correctly treats the `data` property as a JSON object rather than parsing as a String